### PR TITLE
修复样式问题，以及与Lite_Tools的隐藏图标功能兼容性

### DIFF
--- a/src/app/assets/logo.svg
+++ b/src/app/assets/logo.svg
@@ -1,16 +1,8 @@
-<svg width="640" height="480" viewBox="100.18 69.82 160.86 129.97" xmlns="http://www.w3.org/2000/svg"
-     xmlns:svg="http://www.w3.org/2000/svg">
-    <!-- Created with SVG-edit - https://github.com/SVG-Edit/svgedit-->
-    <!-- Drawn by @pk5ls20 referencing https://github.com/hv0905/NekoImageGallery.App/blob/master/misc/logo.psd -->
-    <g class="layer">
-        <title>Layer 1</title>
-        <rect fill="none" height="98.75" id="svg_1" stroke="currentColor" stroke-width="7"
-              transform="matrix(1 0 0 1 0 0)" width="160" x="101.04" y="101.04"/>
-        <path d="m231.49,130.64c0,0 -30.21,20.21 -30.21,20.21c0,0 30,20.21 30,20.21" fill="none" id="svg_21"
-              stroke="currentColor" stroke-width="7" transform="matrix(1 0 0 1 0 0)"/>
-        <path d="m129.5,170.68c0,0 29.86,-20.74 29.86,-20.74c0,0 -30.35,-19.69 -30.35,-19.69" fill="none" id="svg_22"
-              stroke="currentColor" stroke-width="7" transform="matrix(1 0 0 1 0 0)"/>
-        <path d="m100.18,100.9c0,0 28.92,-31.08 28.92,-31.08c0,0 49.73,0 49.55,-0.09c-0.18,-0.09 29.91,30.9 29.91,30.9"
-              fill="none" id="svg_24" stroke="currentColor" stroke-width="7"/>
-    </g>
+<svg width="24" height="24" viewBox="100.18 69.82 160.86 129.97" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+<!-- Created with SVG-edit - https://github.com/SVG-Edit/svgedit-->
+<!-- Drawn by @pk5ls20 referencing https://github.com/hv0905/NekoImageGallery.App/blob/master/misc/logo.psd -->
+<rect fill="none" height="98.75" id="svg_1" stroke="currentColor" stroke-width="7" transform="matrix(1 0 0 1 0 0)" width="160" x="101.04" y="101.04"/>
+<path d="m231.49,130.64c0,0 -30.21,20.21 -30.21,20.21c0,0 30,20.21 30,20.21" fill="none" id="svg_21" stroke="currentColor" stroke-width="7" transform="matrix(1 0 0 1 0 0)"/>
+<path d="m129.5,170.68c0,0 29.86,-20.74 29.86,-20.74c0,0 -30.35,-19.69 -30.35,-19.69" fill="none" id="svg_22" stroke="currentColor" stroke-width="7" transform="matrix(1 0 0 1 0 0)"/>
+<path d="m100.18,100.9c0,0 28.92,-31.08 28.92,-31.08c0,0 49.73,0 49.55,-0.09c-0.18,-0.09 29.91,30.9 29.91,30.9" fill="none" id="svg_24" stroke="currentColor" stroke-width="7"/>
 </svg>

--- a/src/renderer/injectChatFuncBar.ts
+++ b/src/renderer/injectChatFuncBar.ts
@@ -18,6 +18,13 @@ export const injectChatFuncBarObserver = new MutationObserver((mutations) => {
             const lastElementChild = funcBar.lastElementChild;
             if (lastElementChild) {
               const openButton = lastElementChild.cloneNode(true) as Element;
+
+              // 查找并修改特定的嵌套 <div> 元素
+              const iconItem = openButton.querySelector('div.icon-item');
+              if (iconItem) {
+                iconItem.id = 'id-func-bar-neko-image';
+                iconItem.setAttribute('aria-label', 'NekoImage');
+              }
               const icon = openButton.getElementsByTagName('i')[0];
               icon.innerHTML = iconHtml;
               openButton.addEventListener('click', () => {


### PR DESCRIPTION
1.调整logo.svg默认大小，避免右键菜单中被意外选中的情况
logo.svg默认大小太大(640*480)，会导致右键菜单开启后，鼠标没有选中任何元素时依然视为选中了Image Search的选项，此时点击鼠标左键不会正常地退出右键菜单，而是被视为点击了Image Search选项
![04bd9c60a50027b262542e6dd6ab1802](https://github.com/pk5ls20/LiteLoaderQQNT-NekoImageGallerySearch/assets/19678081/3d1a2413-64b2-4c59-b4a5-d60183fc3791)

2.为icon-item设置独特id，以兼容Lite_Tools的图标隐藏功能
cloneNode会复制上一个图标的id，例如id-func-bar-microphone_on，而Lite_Tools使用这个id来区分图标，导致如果原本的最后一个图标被设置为隐藏时，NekoImage的图标会被一起隐藏。
现在在cloneNode后，将复制节点的id设定为了独立的id-func-bar-neko-image