### PR TITLE
修复hookIpcSend中空指针bug，解决与Transitio的兼容性问题

### DIFF
--- a/src/main/native/sora/hookipc.ts
+++ b/src/main/native/sora/hookipc.ts
@@ -7,12 +7,14 @@ const hookIpcSend = (sendData: any) => {
   if (data) {
     // console.log('hookIpcSend-0', data);
   }
-  if (event.callbackId && activeCallbackIds.has(event.callbackId)) {
+  if (event?.callbackId && activeCallbackIds.has(event.callbackId)) {
     // console.log('hookIpcSend-1', event.callbackId);
     eventEmitter.emit(event.callbackId, data);
   } else if (Array.isArray(data) && data[0]?.cmdName) {
     // console.log('hookIpcSend-2', data[0]?.cmdName);
     eventEmitter.emit(data[0]?.cmdName, data);
+  } else {
+    console.warn('hookIpcSend: Unexpected sendData format', sendData);
   }
   return sendData;
 };


### PR DESCRIPTION
与[轻量工具箱的这个issue](https://github.com/xiyuesaves/LiteLoaderQQNT-lite_tools/issues/86)类似
当同时启用0.1.1版本的[NekoImageGallerySearch](https://github.com/pk5ls20/LiteLoaderQQNT-NekoImageGallerySearch)与[Transitio](https://github.com/PRO-2684/transitio)时，Transitio会出现无法加载已安装的 CSS 片段的现象。

此pr修复了`hookIpcSend`中空指针bug，使得Transitio可以正常工作